### PR TITLE
Enable Service endpoints and Network Policy Enforcement to support Private Endpoints

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -7,6 +7,8 @@ variable "aks_00_subnet_cidr_blocks" {}
 variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
+variable "iaas_subnet_service_endpoints" {}
+variable "iaas_subnet_enforce_private_link_network_policies" {}
 
 variable "environment" {}
 variable "project" {}

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -8,7 +8,7 @@ variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
 variable "iaas_subnet_service_endpoints" {}
-variable "iaas_subnet_enforce_private_link_network_policies" {}
+variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {}
 
 variable "environment" {}
 variable "project" {}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -37,10 +37,10 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   name = "iaas"
 
-  resource_group_name                           = var.resource_group_name
-  virtual_network_name                          = azurerm_virtual_network.virtual_network.name
-  service_endpoints                             = var.iaas_subnet_service_endpoints
-  enforce_private_link_service_network_policies = var.iaas_subnet_enforce_private_link_network_policies
+  resource_group_name                            = var.resource_group_name
+  virtual_network_name                           = azurerm_virtual_network.virtual_network.name
+  service_endpoints                              = var.iaas_subnet_service_endpoints
+  enforce_private_link_endpoint_network_policies = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 }
 
 ## Application Gateway

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -37,8 +37,10 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   name = "iaas"
 
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  resource_group_name                           = var.resource_group_name
+  virtual_network_name                          = azurerm_virtual_network.virtual_network.name
+  service_endpoints                             = [var.iaas_subnet_service_endpoints]
+  enforce_private_link_service_network_policies = var.iaas_subnet_enforce_private_link_network_policies
 }
 
 ## Application Gateway

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -39,7 +39,7 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   resource_group_name                           = var.resource_group_name
   virtual_network_name                          = azurerm_virtual_network.virtual_network.name
-  service_endpoints                             = [var.iaas_subnet_service_endpoints]
+  service_endpoints                             = var.iaas_subnet_service_endpoints
   enforce_private_link_service_network_policies = var.iaas_subnet_enforce_private_link_network_policies
 }
 


### PR DESCRIPTION
### Change description ###
Adding support for service endpoints and enforcing endpoint network policies.  This is required to support the use of private endpoints by MI Data Platform.

The Terraform azurerm_subnet resource provider requires  'enforce_private_link_endpoint_network_policies' set to 'true' to deploy a private endpoint on a given subnet.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
