### PR TITLE
Enable Service endpoints and Network Policy Enforcement to support Private Endpoints - Set vars defaults

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -14,7 +14,9 @@ variable "iaas_subnet_service_endpoints" {
         "Microsoft.Sql"
     ]
 }
-variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {}
+variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
+    default = true
+}
 
 variable "environment" {}
 variable "project" {}

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -7,7 +7,13 @@ variable "aks_00_subnet_cidr_blocks" {}
 variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
-variable "iaas_subnet_service_endpoints" {}
+variable "iaas_subnet_service_endpoints" {
+    default = [
+        "Microsoft.Storage",
+        "Microsoft.KeyVault",
+        "Microsoft.Sql"
+    ]
+}
 variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {}
 
 variable "environment" {}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -39,7 +39,7 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  service_endpoints                              = var.iaas_subnet_service_endpoints
+  service_endpoints                              = flatten([var.iaas_subnet_service_endpoints])
   enforce_private_link_endpoint_network_policies = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 }
 

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -39,7 +39,7 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  service_endpoints                              = flatten([var.iaas_subnet_service_endpoints])
+  service_endpoints                              = var.iaas_subnet_service_endpoints
   enforce_private_link_endpoint_network_policies = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 }
 


### PR DESCRIPTION
### Change description ###

Update module to set defaults for service endpoints and enforcing endpoint network policies as discussed in [this PR](https://github.com/hmcts/aks-build-infrastructure/pull/8).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
