### PR TITLE
Enable Service Endpoints on AKS subnets

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -7,13 +7,14 @@ variable "aks_00_subnet_cidr_blocks" {}
 variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
-variable "iaas_subnet_service_endpoints" {
+variable "subnet_service_endpoints" {
     default = [
         "Microsoft.Storage",
         "Microsoft.KeyVault",
         "Microsoft.Sql"
     ]
 }
+
 variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
     default = true
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -15,6 +15,7 @@ resource "azurerm_subnet" "aks_00_subnet" {
 
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.virtual_network.name
+  service_endpoints    = var.subnet_service_endpoints
 }
 
 ## AKS-01
@@ -28,6 +29,8 @@ resource "azurerm_subnet" "aks_01_subnet" {
 
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.virtual_network.name
+  service_endpoints    = var.subnet_service_endpoints
+
 }
 
 ## Iaas 
@@ -39,7 +42,7 @@ resource "azurerm_subnet" "iaas_subnet" {
 
   resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  service_endpoints                              = var.iaas_subnet_service_endpoints
+  service_endpoints                              = var.subnet_service_endpoints
   enforce_private_link_endpoint_network_policies = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###


### Change description ###
Update module to enable service endpoints on shared services AKS subnets in addition to IaaS subnet.

This had been manually enabled on the AKS subnets but removed by [previous PR](https://github.com/hmcts/aks-module-network/pull/6).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
