### PR TITLE
Move subnets creation and route table association to for_each

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -1,3 +1,4 @@
 terraform {
   required_version = ">= 0.12.0"
+  experiments      = [module_variable_optional_attrs]
 }

--- a/00-init.tf
+++ b/00-init.tf
@@ -1,4 +1,3 @@
 terraform {
   required_version = ">= 0.12.0"
-  experiments      = [module_variable_optional_attrs]
 }

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -3,25 +3,14 @@ variable "resource_group_name" {}
 variable "network_location" {}
 variable "network_shortname" {}
 variable "network_address_space" {}
-variable "subnet_service_endpoints" {
-  default = [
-    "Microsoft.Storage",
-    "Microsoft.KeyVault",
-    "Microsoft.Sql"
-  ]
-}
-
-variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
-  default = true
-}
 
 variable "subnets" {
   type = list(object({
     name                                           = string
     address_prefix                                 = string
-    subnet_service_endpoints                       = optional(bool)
-    enforce_private_link_endpoint_network_policies = optional(bool)
-    route_table                                    = optional(bool)
+    subnet_service_endpoints                       = list(string)
+    enforce_private_link_endpoint_network_policies = bool
+    route_table                                    = bool
   }))
 }
 

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -3,10 +3,6 @@ variable "resource_group_name" {}
 variable "network_location" {}
 variable "network_shortname" {}
 variable "network_address_space" {}
-variable "aks_00_subnet_cidr_blocks" {}
-variable "aks_01_subnet_cidr_blocks" {}
-variable "iaas_subnet_cidr_blocks" {}
-variable "application_gateway_subnet_cidr_blocks" {}
 variable "subnet_service_endpoints" {
   default = [
     "Microsoft.Storage",
@@ -17,6 +13,16 @@ variable "subnet_service_endpoints" {
 
 variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
   default = true
+}
+
+variable "subnets" {
+  type = list(object({
+    name                                           = string
+    address_prefix                                 = string
+    subnet_service_endpoints                       = optional(bool)
+    enforce_private_link_endpoint_network_policies = optional(bool)
+    route_table                                    = optional(bool)
+  }))
 }
 
 variable "environment" {}

--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -13,18 +13,6 @@ variable "route_next_hop_type" {
 variable "route_next_hop_in_ip_address" {
   default = "10.10.1.1"
 }
-
-variable "additional_routes" {
-  type = list(object({
-    name                   = string
-    address_prefix         = string
-    next_hop_type          = string
-    next_hop_in_ip_address = string
-  }))
-
-  default = []
-}
-
 variable "additional_subnets" {
   type = list(object({
     name                                         = string

--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -13,11 +13,3 @@ variable "route_next_hop_type" {
 variable "route_next_hop_in_ip_address" {
   default = "10.10.1.1"
 }
-variable "additional_subnets" {
-  type = list(object({
-    name                                         = string
-    address_prefix                               = string
-  }))
-
-  default = []
-}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -11,8 +11,8 @@ resource "azurerm_subnet" "subnets" {
   address_prefixes                               = [each.value.address_prefix]
   resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link_endpoint_network_policies == null ? false : var.iaas_subnet_enforce_private_link_endpoint_network_policies
-  service_endpoints                              = each.value.subnet_service_endpoints == null ? [] : var.subnet_service_endpoints
+  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link_endpoint_network_policies
+  service_endpoints                              = each.value.subnet_service_endpoints
 }
 
 # Route Table


### PR DESCRIPTION
### Change description ###
Move subnets creation and route table association to for_each
- .tfvars example, https://github.com/hmcts/aks-cft-deploy/blob/update-network-subnets/environments/network/sbox.tfvars#L9-L33

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
