### PR TITLE
Add service endpoints to postgresql subnet

### DIFF
--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -33,3 +33,14 @@ variable "additional_subnets" {
 
   default = []
 }
+
+variable "additional_routes_appgw" {
+  type = list(object({
+    name                   = string
+    address_prefix         = string
+    next_hop_type          = string
+    next_hop_in_ip_address = string
+  }))
+
+  default = []
+}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -77,6 +77,8 @@ resource "azurerm_subnet" "postgresql_subnet" {
       ]
     }
   }
+  
+  service_endpoints    = var.subnet_service_endpoints
 }
 
 ## Additional Subnets

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -172,7 +172,34 @@ resource "azurerm_subnet_route_table_association" "appgw" {
   subnet_id      = azurerm_subnet.application_gateway_subnet.id
 }
 
+resource "azurerm_route_table" "route_table_appgw" {
+  name = format("%s-%s-appgw-route-table",
+    var.service_shortname,
+    var.environment
+  )
+
+  location            = var.network_location
+  resource_group_name = var.resource_group_name
+}
+
 resource "azurerm_subnet_route_table_association" "postgresql" {
   route_table_id = azurerm_route_table.route_table.id
   subnet_id      = azurerm_subnet.postgresql_subnet.id
+}
+
+resource "azurerm_subnet_route_table_association" "application_gateway_subnet" {
+  route_table_id = azurerm_route_table.route_table_appgw.id
+  subnet_id      = azurerm_subnet.application_gateway_subnet.id
+}
+
+resource "azurerm_route" "additional_route_appgw" {
+  for_each = { for route in var.additional_routes_appgw : route.name => route }
+
+  name                   = lower(each.value.name)
+  route_table_name       = azurerm_route_table.route_table_appgw.name
+  resource_group_name    = var.resource_group_name
+  address_prefix         = each.value.address_prefix
+  next_hop_type          = each.value.next_hop_type
+  next_hop_in_ip_address = each.value.next_hop_type != "VirtualAppliance" ? null : each.value.next_hop_in_ip_address
+
 }


### PR DESCRIPTION
### Change description ###
Ensure `Microsoft.Storage` service endpoint is added to postgresql subnet to allow HA to be enabled
Also merge changes from `cft` branch to bring master in line

Raised as a result of Microsoft disabling HA on a flexible postgres server
Link to aks-sds-deploy pipeline using the branch: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=387593&view=results
Link to aks-cft-deploy pipeline using the branch: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=387685&view=results

aks-cft-deploy main is using the cft branch of this repo. I will check out updating that to master when the issues with the pipeline are fixed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
