### PR TITLE
Remove duplicate appgw route table creation, align additional routes TF var across SDS & CFT deploy repos

### DIFF
--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -8,7 +8,7 @@ variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
 variable "postgresql_subnet_cidr_blocks" {}
-variable "application_gateway_routes" {
+variable "additional_routes_appgw" {
   default = []
 }
 variable "subnet_service_endpoints" {

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -8,9 +8,6 @@ variable "aks_01_subnet_cidr_blocks" {}
 variable "iaas_subnet_cidr_blocks" {}
 variable "application_gateway_subnet_cidr_blocks" {}
 variable "postgresql_subnet_cidr_blocks" {}
-variable "additional_routes_appgw" {
-  default = []
-}
 variable "subnet_service_endpoints" {
   default = [
     "Microsoft.Storage",

--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -34,7 +34,7 @@ variable "additional_subnets" {
   default = []
 }
 
-variable "additional_routes_appgw" {
+variable "additional_routes_application_gateway" {
   type = list(object({
     name                   = string
     address_prefix         = string

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -169,7 +169,7 @@ resource "azurerm_subnet_route_table_association" "application_gateway_subnet" {
 }
 
 resource "azurerm_route" "additional_route_appgw" {
-  for_each = { for route in var.application_gateway_routes : route.name => route }
+  for_each = { for route in var.additional_routes_appgw : route.name => route }
 
   name                   = lower(each.value.name)
   route_table_name       = azurerm_route_table.route_table_appgw.name

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -106,19 +106,6 @@ resource "azurerm_route_table" "route_table" {
   tags                = var.tags
 }
 
-resource "azurerm_route_table" "appgw" {
-  count = var.application_gateway_routes == [] ? 0 : 1
-
-  name = format("%s-%s-appgw-route-table",
-    var.service_shortname,
-    var.environment
-  )
-
-  location            = var.network_location
-  resource_group_name = var.resource_group_name
-  tags                = var.tags
-}
-
 resource "azurerm_route" "default_route" {
   name                   = var.route_name
   route_table_name       = azurerm_route_table.route_table.name
@@ -137,18 +124,6 @@ resource "azurerm_route" "additional_route" {
   address_prefix         = each.value.address_prefix
   next_hop_type          = each.value.next_hop_type
   next_hop_in_ip_address = each.value.next_hop_type != "VirtualAppliance" ? null : each.value.next_hop_in_ip_address
-}
-
-resource "azurerm_route" "appgw" {
-  for_each = { for route in var.application_gateway_routes : route.name => route }
-
-  name                   = lower(each.value.name)
-  route_table_name       = azurerm_route_table.appgw[0].name
-  resource_group_name    = var.resource_group_name
-  address_prefix         = each.value.address_prefix
-  next_hop_type          = each.value.next_hop_type
-  next_hop_in_ip_address = each.value.next_hop_type != "VirtualAppliance" ? null : each.value.next_hop_in_ip_address
-
 }
 
 resource "azurerm_subnet_route_table_association" "aks_00" {
@@ -194,7 +169,7 @@ resource "azurerm_subnet_route_table_association" "application_gateway_subnet" {
 }
 
 resource "azurerm_route" "additional_route_appgw" {
-  for_each = { for route in var.additional_routes_appgw : route.name => route }
+  for_each = { for route in var.application_gateway_routes : route.name => route }
 
   name                   = lower(each.value.name)
   route_table_name       = azurerm_route_table.route_table_appgw.name
@@ -202,5 +177,4 @@ resource "azurerm_route" "additional_route_appgw" {
   address_prefix         = each.value.address_prefix
   next_hop_type          = each.value.next_hop_type
   next_hop_in_ip_address = each.value.next_hop_type != "VirtualAppliance" ? null : each.value.next_hop_in_ip_address
-
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -163,7 +163,7 @@ resource "azurerm_subnet_route_table_association" "application_gateway_subnet" {
 }
 
 resource "azurerm_route" "additional_route_appgw" {
-  for_each = { for route in var.additional_routes_appgw : route.name => route }
+  for_each = { for route in var.additional_routes_application_gateway : route.name => route }
 
   name                   = lower(each.value.name)
   route_table_name       = azurerm_route_table.route_table_appgw.name

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -178,3 +178,8 @@ resource "azurerm_route" "additional_route_appgw" {
   next_hop_type          = each.value.next_hop_type
   next_hop_in_ip_address = each.value.next_hop_type != "VirtualAppliance" ? null : each.value.next_hop_in_ip_address
 }
+
+moved {
+  from = azurerm_route_table.appgw[0]
+  to   = azurerm_route_table.route_table_appgw
+}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -141,12 +141,6 @@ resource "azurerm_subnet_route_table_association" "iaas" {
   subnet_id      = azurerm_subnet.iaas_subnet.id
 }
 
-resource "azurerm_subnet_route_table_association" "appgw" {
-  count          = var.additional_routes_appgw == [] ? 0 : 1
-  route_table_id = azurerm_route_table.route_table_appgw.id
-  subnet_id      = azurerm_subnet.application_gateway_subnet.id
-}
-
 resource "azurerm_route_table" "route_table_appgw" {
   name = format("%s-%s-appgw-route-table",
     var.service_shortname,
@@ -187,4 +181,9 @@ moved {
 moved {
   from = azurerm_route.appgw
   to   = azurerm_route.additional_route_appgw
+}
+
+moved {
+  from = azurerm_subnet_route_table_association.appgw
+  to   = azurerm_subnet_route_table_association.application_gateway_subnet
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -187,18 +187,3 @@ moved {
   from = azurerm_subnet_route_table_association.appgw
   to   = azurerm_subnet_route_table_association.application_gateway_subnet
 }
-
-moved {
-  from = azurerm_subnet_route_table_association.appgw[0]
-  to   = azurerm_subnet_route_table_association.application_gateway_subnet
-}
-
-moved {
-  from = azurerm_subnet_route_table_association.appgw[1]
-  to   = azurerm_subnet_route_table_association.application_gateway_subnet
-}
-
-moved {
-  from = azurerm_subnet_route_table_association.appgw[3]
-  to   = azurerm_subnet_route_table_association.application_gateway_subnet
-}

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -184,6 +184,6 @@ moved {
 }
 
 moved {
-  from = azurerm_subnet_route_table_association.appgw
+  from = azurerm_subnet_route_table_association.appgw[0]
   to   = azurerm_subnet_route_table_association.application_gateway_subnet
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -184,6 +184,21 @@ moved {
 }
 
 moved {
+  from = azurerm_subnet_route_table_association.appgw
+  to   = azurerm_subnet_route_table_association.application_gateway_subnet
+}
+
+moved {
   from = azurerm_subnet_route_table_association.appgw[0]
+  to   = azurerm_subnet_route_table_association.application_gateway_subnet
+}
+
+moved {
+  from = azurerm_subnet_route_table_association.appgw[1]
+  to   = azurerm_subnet_route_table_association.application_gateway_subnet
+}
+
+moved {
+  from = azurerm_subnet_route_table_association.appgw[3]
   to   = azurerm_subnet_route_table_association.application_gateway_subnet
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -142,8 +142,8 @@ resource "azurerm_subnet_route_table_association" "iaas" {
 }
 
 resource "azurerm_subnet_route_table_association" "appgw" {
-  count          = var.application_gateway_routes == [] ? 0 : 1
-  route_table_id = azurerm_route_table.appgw[0].id
+  count          = var.additional_routes_appgw == [] ? 0 : 1
+  route_table_id = azurerm_route_table.route_table_appgw.id
   subnet_id      = azurerm_subnet.application_gateway_subnet.id
 }
 

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -183,3 +183,8 @@ moved {
   from = azurerm_route_table.appgw[0]
   to   = azurerm_route_table.route_table_appgw
 }
+
+moved {
+  from = azurerm_route.appgw
+  to   = azurerm_route.additional_route_appgw
+}


### PR DESCRIPTION
### Change description ###

* Align the additional routes TF variable used in the module to add additional routes to appgw route table
* Remove duplicate appgw route table TF resource block now that route creation method is unified for both SDS & CFT


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
