### PR TITLE
adding variable for default_outbound_access_enabled

### DIFF
--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -36,6 +36,7 @@ variable "additional_subnets" {
       actions      = list(string)
     })))
     private_endpoint_network_policies = optional(string, "Disabled")
+    default_outbound_access_enabled = optional(bool, true)
   }))
   default = []
 }

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -118,6 +118,7 @@ resource "azurerm_subnet" "additional_subnets" {
   virtual_network_name              = azurerm_virtual_network.virtual_network.name
   private_endpoint_network_policies = each.value.private_endpoint_network_policies
   service_endpoints                 = each.value.service_endpoints
+  default_outbound_access_enabled   = each.value.default_outbound_access_enabled
 
   dynamic "delegation" {
     for_each = each.value.delegations != null ? each.value.delegations : {}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-30357

### Change description
We are blocking outbound to internet by default for the new crime IDAM subnets by adding "default_outbound_access_enabled = false" as we do not have the UDR in place for the new idam subnet

https://github.com/hmcts/aks-cft-deploy/pull/820/changes

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
