### PR TITLE
Support multi-option instead of multi-rule

### DIFF
--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -38,18 +38,48 @@ variable "additional_subnets" {
       actions      = list(string)
     })))
     nsg_rules = optional(list(object({
-      name                       = string
-      priority                   = number
-      direction                  = string
-      access                     = string
-      protocol                   = string
-      source_port_range          = string
-      destination_port_range     = string
-      source_address_prefix      = string
-      destination_address_prefix = string
+      name                         = string
+      priority                     = number
+      direction                    = string
+      access                       = string
+      protocol                     = string
+      source_port_range            = optional(string)
+      source_port_ranges           = optional(list(string))
+      destination_port_range       = optional(string)
+      destination_port_ranges      = optional(list(string))
+      source_address_prefix        = optional(string)
+      source_address_prefixes      = optional(list(string))
+      destination_address_prefix   = optional(string)
+      destination_address_prefixes = optional(list(string))
     })), [])
   }))
   default = []
+
+  validation {
+    condition = alltrue(flatten([
+      for subnet in var.additional_subnets : [
+        for rule in coalesce(subnet.nsg_rules, []) :
+        (rule.source_port_range == null || rule.source_port_ranges == null) &&
+        (rule.destination_port_range == null || rule.destination_port_ranges == null) &&
+        (rule.source_address_prefix == null || rule.source_address_prefixes == null) &&
+        (rule.destination_address_prefix == null || rule.destination_address_prefixes == null)
+      ]
+    ]))
+    error_message = "For each nsg_rule, set only the singular (e.g. source_port_range) OR the plural (e.g. source_port_ranges) form, not both. This applies to source_port_range/ranges, destination_port_range/ranges, source_address_prefix/prefixes, and destination_address_prefix/prefixes."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for subnet in var.additional_subnets : [
+        for rule in coalesce(subnet.nsg_rules, []) :
+        (rule.source_port_range != null || rule.source_port_ranges != null) &&
+        (rule.destination_port_range != null || rule.destination_port_ranges != null) &&
+        (rule.source_address_prefix != null || rule.source_address_prefixes != null) &&
+        (rule.destination_address_prefix != null || rule.destination_address_prefixes != null)
+      ]
+    ]))
+    error_message = "For each nsg_rule, you must set one of source_port_range/ranges, one of destination_port_range/ranges, one of source_address_prefix/prefixes, and one of destination_address_prefix/prefixes."
+  }
 }
 
 variable "additional_routes_application_gateway" {

--- a/12-connectivity.tf
+++ b/12-connectivity.tf
@@ -147,33 +147,41 @@ resource "azurerm_network_security_rule" "additional_subnet_nsg_rules" {
     for rule in flatten([
       for subnet in var.additional_subnets : [
         for rule in coalesce(subnet.nsg_rules, []) : {
-          key                        = "${subnet.name}-${rule.name}"
-          subnet_name                = subnet.name
-          name                       = rule.name
-          priority                   = rule.priority
-          direction                  = rule.direction
-          access                     = rule.access
-          protocol                   = rule.protocol
-          source_port_range          = rule.source_port_range
-          destination_port_range     = rule.destination_port_range
-          source_address_prefix      = rule.source_address_prefix
-          destination_address_prefix = rule.destination_address_prefix
+          key                          = "${subnet.name}-${rule.name}"
+          subnet_name                  = subnet.name
+          name                         = rule.name
+          priority                     = rule.priority
+          direction                    = rule.direction
+          access                       = rule.access
+          protocol                     = rule.protocol
+          source_port_range            = rule.source_port_range
+          source_port_ranges           = rule.source_port_ranges
+          destination_port_range       = rule.destination_port_range
+          destination_port_ranges      = rule.destination_port_ranges
+          source_address_prefix        = rule.source_address_prefix
+          source_address_prefixes      = rule.source_address_prefixes
+          destination_address_prefix   = rule.destination_address_prefix
+          destination_address_prefixes = rule.destination_address_prefixes
         }
       ] if length(coalesce(subnet.nsg_rules, [])) > 0
     ]) : rule.key => rule
   }
 
-  name                        = each.value.name
-  priority                    = each.value.priority
-  direction                   = each.value.direction
-  access                      = each.value.access
-  protocol                    = each.value.protocol
-  source_port_range           = each.value.source_port_range
-  destination_port_range      = each.value.destination_port_range
-  source_address_prefix       = each.value.source_address_prefix
-  destination_address_prefix  = each.value.destination_address_prefix
-  resource_group_name         = var.resource_group_name
-  network_security_group_name = azurerm_network_security_group.additional_subnet_nsg[each.value.subnet_name].name
+  name                         = each.value.name
+  priority                     = each.value.priority
+  direction                    = each.value.direction
+  access                       = each.value.access
+  protocol                     = each.value.protocol
+  source_port_range            = each.value.source_port_range
+  source_port_ranges           = each.value.source_port_ranges
+  destination_port_range       = each.value.destination_port_range
+  destination_port_ranges      = each.value.destination_port_ranges
+  source_address_prefix        = each.value.source_address_prefix
+  source_address_prefixes      = each.value.source_address_prefixes
+  destination_address_prefix   = each.value.destination_address_prefix
+  destination_address_prefixes = each.value.destination_address_prefixes
+  resource_group_name          = var.resource_group_name
+  network_security_group_name  = azurerm_network_security_group.additional_subnet_nsg[each.value.subnet_name].name
 }
 
 resource "azurerm_subnet_network_security_group_association" "additional_subnet_nsg" {


### PR DESCRIPTION
Allows to set multiple source and destination address and ports as per https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule instead of requiring a new rule for each IP - also adds validation to make them mutually exclusive

Tested in https://github.com/hmcts/aks-cft-deploy/pull/836